### PR TITLE
Make concurrent-queue loom-aware

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,11 @@ categories = ["concurrency"]
 readme = "README.md"
 
 [dependencies]
-loom = { version = "0.3", optional = true }
 cache-padded = "1.1.1"
 
 [dev-dependencies]
 easy-parallel = "3.1.0"
 fastrand = "1.3.3"
+
+[target.'cfg(loom)'.dependencies]
+loom = { version = "0.3.5" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ categories = ["concurrency"]
 readme = "README.md"
 
 [dependencies]
+loom = { version = "0.3", optional = true }
 cache-padded = "1.1.1"
 
 [dev-dependencies]

--- a/src/bounded.rs
+++ b/src/bounded.rs
@@ -1,7 +1,7 @@
-use std::cell::UnsafeCell;
+use crate::facade::cell::UnsafeCell;
 use std::mem::MaybeUninit;
-use std::sync::atomic::{AtomicUsize, Ordering};
-use std::thread;
+use crate::facade::sync::atomic::{AtomicUsize, Ordering};
+use crate::facade::thread;
 
 use cache_padded::CachePadded;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,11 +33,18 @@
 use std::error;
 use std::fmt;
 use std::panic::{RefUnwindSafe, UnwindSafe};
-use std::sync::atomic::{self, AtomicUsize, Ordering};
+use facade::sync::atomic::{self, AtomicUsize, Ordering};
 
 use crate::bounded::Bounded;
 use crate::single::Single;
 use crate::unbounded::Unbounded;
+
+mod facade {
+    #[cfg(feature = "loom")]
+    pub use loom::{sync, cell, thread};
+    #[cfg(not(feature = "loom"))]
+    pub use std::{sync, cell, thread};
+}
 
 mod bounded;
 mod single;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,11 +39,36 @@ use crate::bounded::Bounded;
 use crate::single::Single;
 use crate::unbounded::Unbounded;
 
+/// An internal facade abstracting over loom and std types
 mod facade {
-    #[cfg(feature = "loom")]
-    pub use loom::{sync, cell, thread};
-    #[cfg(not(feature = "loom"))]
-    pub use std::{sync, cell, thread};
+    pub mod sync {
+        #[cfg(feature = "loom")]
+        pub use loom::sync::*;
+        #[cfg(not(feature = "loom"))]
+        pub use std::sync::*;
+
+        pub mod atomic {
+            #[cfg(feature = "loom")]
+            pub use loom::sync::atomic::*;
+
+            #[cfg(not(feature = "loom"))]
+            pub use std::sync::atomic::*;
+        }
+    }
+
+    pub mod cell {
+        #[cfg(feature = "loom")]
+        pub use loom::cell::*;
+        #[cfg(not(feature = "loom"))]
+        pub use std::cell::*;
+    }
+
+    pub mod thread {
+        #[cfg(feature = "loom")]
+        pub use loom::thread::*;
+        #[cfg(not(feature = "loom"))]
+        pub use std::thread::*;
+    }
 }
 
 mod bounded;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,23 +42,24 @@ use crate::unbounded::Unbounded;
 /// An internal facade abstracting over loom and std types
 mod facade {
     pub mod sync {
-        #[cfg(feature = "loom")]
+        #[cfg(loom)]
         pub use loom::sync::*;
-        #[cfg(not(feature = "loom"))]
+        #[cfg(not(loom))]
         pub use std::sync::*;
 
         pub mod atomic {
-            #[cfg(feature = "loom")]
+            #[cfg(loom)]
             pub use loom::sync::atomic::*;
 
-            #[cfg(not(feature = "loom"))]
+            #[cfg(not(loom))]
             pub use std::sync::atomic::*;
 
+            // TODO(loom): loom may add get_mut to &mut AtomicUsize in the future
             pub fn load_unique(atomic: &mut AtomicUsize) -> usize {
-                #[cfg(feature = "loom")]
+                #[cfg(loom)]
                 let v = unsafe { atomic.unsync_load() }; // SAFETY: we have &mut
 
-                #[cfg(not(feature = "loom"))]
+                #[cfg(not(loom))]
                 let v = *atomic.get_mut();
 
                 v
@@ -67,24 +68,26 @@ mod facade {
     }
 
     pub mod cell {
-        #[cfg(feature = "loom")]
+        #[cfg(loom)]
         pub use loom::cell::*;
-        #[cfg(not(feature = "loom"))]
+        #[cfg(not(loom))]
         pub use std::cell::*;
 
+        // TODO(loom): loom may add get() to &mut AtomicUsize in the future
         pub unsafe fn write<T>(cell: &UnsafeCell<T>, value: T) {
-            #[cfg(feature = "loom")]
+            #[cfg(loom)]
             cell.with_mut(|ptr| ptr.write(value));
 
-            #[cfg(not(feature = "loom"))]
+            #[cfg(not(loom))]
             cell.get().write(value);
         }
 
+        // TODO(loom): loom may add get() to &mut AtomicUsize in the future
         pub unsafe fn read<T>(cell: &UnsafeCell<T>) -> T {
-            #[cfg(feature = "loom")]
+            #[cfg(loom)]
             let v = cell.with(|ptr| ptr.read());
 
-            #[cfg(not(feature = "loom"))]
+            #[cfg(not(loom))]
             let v = cell.get().read();
 
             v
@@ -92,9 +95,9 @@ mod facade {
     }
 
     pub mod thread {
-        #[cfg(feature = "loom")]
+        #[cfg(loom)]
         pub use loom::thread::*;
-        #[cfg(not(feature = "loom"))]
+        #[cfg(not(loom))]
         pub use std::thread::*;
     }
 }

--- a/src/single.rs
+++ b/src/single.rs
@@ -1,7 +1,7 @@
-use std::cell::UnsafeCell;
+use crate::facade::cell::UnsafeCell;
 use std::mem::MaybeUninit;
-use std::sync::atomic::{AtomicUsize, Ordering};
-use std::thread;
+use crate::facade::sync::atomic::{AtomicUsize, Ordering};
+use crate::facade::thread;
 
 use crate::{PopError, PushError};
 

--- a/src/single.rs
+++ b/src/single.rs
@@ -1,9 +1,10 @@
 use crate::facade::cell::UnsafeCell;
 use std::mem::MaybeUninit;
 use crate::facade::sync::atomic::{AtomicUsize, Ordering};
-use crate::facade::thread;
+use crate::facade::{thread, cell};
 
 use crate::{PopError, PushError};
+use crate::facade::sync::atomic;
 
 const LOCKED: usize = 1 << 0;
 const PUSHED: usize = 1 << 1;
@@ -33,7 +34,7 @@ impl<T> Single<T> {
 
         if state == 0 {
             // Write the value and unlock.
-            unsafe { self.slot.get().write(MaybeUninit::new(value)) }
+            unsafe { cell::write(&self.slot, MaybeUninit::new(value)) }
             self.state.fetch_and(!LOCKED, Ordering::Release);
             Ok(())
         } else if state & CLOSED != 0 {
@@ -54,7 +55,7 @@ impl<T> Single<T> {
 
             if prev == state {
                 // Read the value and unlock.
-                let value = unsafe { self.slot.get().read().assume_init() };
+                let value = unsafe { cell::read(&self.slot).assume_init() };
                 self.state.fetch_and(!LOCKED, Ordering::Release);
                 return Ok(value);
             }
@@ -112,8 +113,8 @@ impl<T> Single<T> {
 impl<T> Drop for Single<T> {
     fn drop(&mut self) {
         // Drop the value in the slot.
-        if *self.state.get_mut() & PUSHED != 0 {
-            let value = unsafe { self.slot.get().read().assume_init() };
+        if atomic::load_unique(&mut self.state) & PUSHED != 0 {
+            let value = unsafe { cell::read(&self.slot).assume_init() };
             drop(value);
         }
     }

--- a/src/unbounded.rs
+++ b/src/unbounded.rs
@@ -1,8 +1,8 @@
-use std::cell::UnsafeCell;
+use crate::facade::cell::UnsafeCell;
 use std::mem::MaybeUninit;
 use std::ptr;
-use std::sync::atomic::{AtomicPtr, AtomicUsize, Ordering};
-use std::thread;
+use crate::facade::sync::atomic::{AtomicPtr, AtomicUsize, Ordering};
+use crate::facade::thread;
 
 use cache_padded::CachePadded;
 

--- a/src/unbounded.rs
+++ b/src/unbounded.rs
@@ -37,7 +37,7 @@ struct Slot<T> {
 }
 
 impl<T> Slot<T> {
-    #[cfg(not(feature = "loom"))]
+    #[cfg(not(loom))]
     const UNINIT: Slot<T> = Slot {
         value: UnsafeCell::new(MaybeUninit::uninit()),
         state: AtomicUsize::new(0),
@@ -65,10 +65,10 @@ struct Block<T> {
 impl<T> Block<T> {
     /// Creates an empty block.
     fn new() -> Block<T> {
-        #[cfg(not(feature = "loom"))]
+        #[cfg(not(loom))]
         let slots = [Slot::UNINIT; BLOCK_CAP];
 
-        #[cfg(feature = "loom")]
+        #[cfg(loom)]
         let slots = {
             use std::convert::TryFrom;
 


### PR DESCRIPTION
This PR implements [loom](https://github.com/tokio-rs/loom/)-awareness for concurrent-queue. Particularly, downstream users can pass `--cfg loom` to rustc via `RUSTFLAGS` in order to then run loom tests for their crates using concurrent-queue, and have loom be able to test/track the concurrent-queue parts too.

I'm not sure how this interacts with the CI. Ideally, the checking should be run with both loom on and off, the normal tests with loom off, and any loom tests with loom on. In order to enable loom, RUSTFLAGS must be set to have `--cfg loom`. I haven't written any loom tests for concurrent-queue in this PR yet, though that could come in subsequent work.