### PR TITLE
bounded: make sure lap does not overflow into index

### DIFF
--- a/src/bounded.rs
+++ b/src/bounded.rs
@@ -106,7 +106,7 @@ impl<T> Bounded<T> {
                 } else {
                     // One lap forward, index wraps around to zero.
                     // Set to `{ lap: lap.wrapping_add(1), mark: 0, index: 0 }`.
-                    lap.wrapping_add(self.one_lap)
+                    lap.wrapping_add(self.one_lap) & !(self.one_lap - 1)
                 };
 
                 // Try moving the tail.
@@ -169,7 +169,7 @@ impl<T> Bounded<T> {
                 } else {
                     // One lap forward, index wraps around to zero.
                     // Set to `{ lap: lap.wrapping_add(1), mark: 0, index: 0 }`.
-                    lap.wrapping_add(self.one_lap)
+                    lap.wrapping_add(self.one_lap) & !(self.one_lap - 1)
                 };
 
                 // Try moving the head.


### PR DESCRIPTION
.wrapping_add() is not enuough to ensure this, it is possible to end
up with index=1 if usize overflows. This is unlikely on 64-bit
systems, but possible on 32-bit systems.