### PR TITLE
Add benchmarks for unbounded queues

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,17 @@ documentation = "https://docs.rs/concurrent-queue"
 keywords = ["channel", "mpmc", "spsc", "spmc", "mpsc"]
 categories = ["concurrency"]
 
+[lib]
+bench = false
+
 [dependencies]
 cache-padded = "1.1.1"
 
+[[bench]]
+name = "bench"
+harness = false
+
 [dev-dependencies]
+criterion = "0.3.4"
 easy-parallel = "3.1.0"
 fastrand = "1.3.3"

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,0 +1,88 @@
+use std::{
+    any::type_name,
+    fmt::Debug,
+};
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use concurrent_queue::{ConcurrentQueue, PopError};
+use easy_parallel::Parallel;
+
+const COUNT: usize = 100_000;
+const THREADS: usize = 7;
+
+fn spsc<T: Default + std::fmt::Debug + Send>(recv: &ConcurrentQueue<T>, send: &ConcurrentQueue<T>) {
+    Parallel::new()
+        .add(|| {
+            loop {
+                match recv.pop() {
+                    Ok(_) => (),
+                    Err(PopError::Empty) => (),
+                    Err(PopError::Closed) => break,
+                }
+            }
+        })
+        .add(|| {
+            for _ in 0..COUNT {
+                send.push(T::default()).unwrap();
+            }
+            send.close();
+        })
+        .run();
+}
+
+fn mpsc<T: Default + std::fmt::Debug + Send>(recv: &ConcurrentQueue<T>, send: &ConcurrentQueue<T>) {
+    Parallel::new()
+        .each(0..THREADS, |_| {
+            for _ in 0.. COUNT {
+                send.push(T::default()).unwrap();
+            }
+        })
+        .add(|| {
+            let mut recieved = 0;
+            while recieved < THREADS * COUNT {
+                match recv.pop() {
+                    Ok(_) => recieved += 1,
+                    Err(PopError::Empty) => (),
+                    Err(PopError::Closed) => unreachable!()
+                }
+            }
+        })
+        .run();
+}
+
+fn single_thread<T: Default + std::fmt::Debug>(recv: &ConcurrentQueue<T>, send: &ConcurrentQueue<T>) {
+    for _ in 0.. COUNT {
+        send.push(T::default()).unwrap();
+    }
+    for _ in 0.. COUNT {
+        recv.pop().unwrap();
+    }
+}
+
+// Because we can't pass generic functions as const parameters.
+macro_rules! bench_all(
+    ($name:ident, $f:ident) => {
+        fn $name(c: &mut Criterion) {
+            fn helper<T: Default + Debug + Send>(c: &mut Criterion) {
+                let name = format!("unbounded_{}_{}", stringify!($f), type_name::<T>());
+
+                c.bench_function(&name, |b| b.iter(|| {
+                    let q = ConcurrentQueue::unbounded();
+                    $f::<T>(black_box(&q), black_box(&q));
+                }));
+            }
+            helper::<u8>(c);
+            helper::<u16>(c);
+            helper::<u32>(c);
+            helper::<u64>(c);
+            helper::<u128>(c);
+        }
+    }
+);
+
+bench_all!(bench_spsc, spsc);
+bench_all!(bench_mpsc, mpsc);
+bench_all!(bench_single_thread, single_thread);
+
+criterion_group!(generic_group, bench_single_thread, bench_spsc, bench_mpsc);
+criterion_main!(generic_group);


### PR DESCRIPTION
Does what it says on the tin.

I wrote this planning to propose changing the `AtomicUsize` in [`unbounded::Slot`](https://github.com/smol-rs/concurrent-queue/blob/edb1210403e23ad65b24a8a5c4fc1af3f845d5b0/src/unbounded.rs#L36) to an `AtomicU8`, turns out that doesn't really improve performance though so I won't be submitting that PR (image of benchmark attached, since the colors really help).

![image](https://user-images.githubusercontent.com/595972/119274853-ffe17980-bbdf-11eb-9a79-7c808d4c81b6.png)
