### PR TITLE
Revert "Fix fence on non-x86 arch and miri (#16)"

### DIFF
--- a/src/bounded.rs
+++ b/src/bounded.rs
@@ -129,7 +129,8 @@ impl<T> Bounded<T> {
                     }
                 }
             } else if stamp.wrapping_add(self.one_lap) == tail + 1 {
-                let head = crate::full_fence_for_load(|| self.head.load(Ordering::Relaxed));
+                crate::full_fence();
+                let head = self.head.load(Ordering::Relaxed);
 
                 // If the head lags one lap behind the tail as well...
                 if head.wrapping_add(self.one_lap) == tail {
@@ -190,7 +191,8 @@ impl<T> Bounded<T> {
                     }
                 }
             } else if stamp == head {
-                let tail = crate::full_fence_for_load(|| self.tail.load(Ordering::Relaxed));
+                crate::full_fence();
+                let tail = self.tail.load(Ordering::Relaxed);
 
                 // If the tail equals the head, that means the queue is empty.
                 if (tail & !self.mark_bit) == head {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -459,8 +459,10 @@ fn full_fence() {
         // The ideal solution here would be to use inline assembly, but we're instead creating a
         // temporary atomic variable and compare-and-exchanging its value. No sane compiler to
         // x86 platforms is going to optimize this away.
+        atomic::compiler_fence(Ordering::SeqCst);
         let a = AtomicUsize::new(0);
         let _ = a.compare_exchange(0, 1, Ordering::SeqCst, Ordering::SeqCst);
+        atomic::compiler_fence(Ordering::SeqCst);
     } else {
         atomic::fence(Ordering::SeqCst);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -446,7 +446,10 @@ impl<T> fmt::Display for PushError<T> {
 /// Equivalent to `atomic::fence(Ordering::SeqCst)`, but in some cases faster.
 #[inline]
 fn full_fence() {
-    if cfg!(any(target_arch = "x86", target_arch = "x86_64")) {
+    if cfg!(all(
+        any(target_arch = "x86", target_arch = "x86_64"),
+        not(miri)
+    )) {
         // HACK(stjepang): On x86 architectures there are two different ways of executing
         // a `SeqCst` fence.
         //

--- a/src/unbounded.rs
+++ b/src/unbounded.rs
@@ -237,7 +237,8 @@ impl<T> Unbounded<T> {
             let mut new_head = head + (1 << SHIFT);
 
             if new_head & MARK_BIT == 0 {
-                let tail = crate::full_fence_for_load(|| self.tail.index.load(Ordering::Relaxed));
+                crate::full_fence();
+                let tail = self.tail.index.load(Ordering::Relaxed);
 
                 // If the tail equals the head, that means the queue is empty.
                 if head >> SHIFT == tail >> SHIFT {


### PR DESCRIPTION
Based on the discussion in #17:

- Revert #16 for now (v1.2.3 is already yanked)
- Use compiler_fence in full_fence on x86
- Do not use x86 specific fence on Miri (because Miri doesn't understand it)

The fence for the unbounded queue needs to be fixed again in some way, but for now, I'm going to revert all of them.

@sbarral Any thoughts?