### PR TITLE
Optimize Drop impls

### DIFF
--- a/src/bounded.rs
+++ b/src/bounded.rs
@@ -312,8 +312,8 @@ impl<T> Drop for Bounded<T> {
             // Drop the value in the slot.
             let slot = &self.buffer[index];
             unsafe {
-                let value = slot.value.get().read().assume_init();
-                drop(value);
+                let value = &mut *slot.value.get();
+                value.as_mut_ptr().drop_in_place();
             }
         }
     }

--- a/src/single.rs
+++ b/src/single.rs
@@ -120,8 +120,10 @@ impl<T> Drop for Single<T> {
     fn drop(&mut self) {
         // Drop the value in the slot.
         if *self.state.get_mut() & PUSHED != 0 {
-            let value = unsafe { self.slot.get().read().assume_init() };
-            drop(value);
+            unsafe {
+                let value = &mut *self.slot.get();
+                value.as_mut_ptr().drop_in_place();
+            }
         }
     }
 }

--- a/src/unbounded.rs
+++ b/src/unbounded.rs
@@ -387,8 +387,8 @@ impl<T> Drop for Unbounded<T> {
                 if offset < BLOCK_CAP {
                     // Drop the value in the slot.
                     let slot = (*block).slots.get_unchecked(offset);
-                    let value = slot.value.get().read().assume_init();
-                    drop(value);
+                    let value = &mut *slot.value.get();
+                    value.as_mut_ptr().drop_in_place();
                 } else {
                     // Deallocate the block and move to the next one.
                     let next = *(*block).next.get_mut();

--- a/src/unbounded.rs
+++ b/src/unbounded.rs
@@ -371,9 +371,9 @@ impl<T> Unbounded<T> {
 
 impl<T> Drop for Unbounded<T> {
     fn drop(&mut self) {
-        let mut head = self.head.index.load(Ordering::Relaxed);
-        let mut tail = self.tail.index.load(Ordering::Relaxed);
-        let mut block = self.head.block.load(Ordering::Relaxed);
+        let mut head = *self.head.index.get_mut();
+        let mut tail = *self.tail.index.get_mut();
+        let mut block = *self.head.block.get_mut();
 
         // Erase the lower bits.
         head &= !((1 << SHIFT) - 1);
@@ -391,7 +391,7 @@ impl<T> Drop for Unbounded<T> {
                     drop(value);
                 } else {
                     // Deallocate the block and move to the next one.
-                    let next = (*block).next.load(Ordering::Relaxed);
+                    let next = *(*block).next.get_mut();
                     drop(Box::from_raw(block));
                     block = next;
                 }


### PR DESCRIPTION
- Use get_mut instead of atomic load in Drop impls
- Do not copy data before dropping