### PR TITLE
Replace cache_padded with crossbeam-utils

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ exclude = ["/.*"]
 bench = false
 
 [dependencies]
-cache-padded = "1.1.1"
+crossbeam-utils = { version = "0.8.11", default-features = false }
 
 [[bench]]
 name = "bench"

--- a/src/bounded.rs
+++ b/src/bounded.rs
@@ -3,7 +3,7 @@ use core::cell::UnsafeCell;
 use core::mem::MaybeUninit;
 use core::sync::atomic::{AtomicUsize, Ordering};
 
-use cache_padded::CachePadded;
+use crossbeam_utils::CachePadded;
 
 use crate::{busy_wait, PopError, PushError};
 

--- a/src/unbounded.rs
+++ b/src/unbounded.rs
@@ -4,7 +4,7 @@ use core::mem::MaybeUninit;
 use core::ptr;
 use core::sync::atomic::{AtomicPtr, AtomicUsize, Ordering};
 
-use cache_padded::CachePadded;
+use crossbeam_utils::CachePadded;
 
 use crate::{busy_wait, PopError, PushError};
 


### PR DESCRIPTION
`concurrent-queue` is far and ahead the [largest user](https://crates.io/crates/cache-padded/reverse_dependencies) of the `cache-padded` crate. As per discussion in smol-rs/cache-padded#10, it should be replaced with the equivalent type in `crossbeam-utils`. This PR makes the conversion.