### PR TITLE
Avoid the breaking change introduced in #22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,10 +46,6 @@ jobs:
       - name: Install Rust
         run: rustup update ${{ matrix.rust }} && rustup default ${{ matrix.rust }}
       - run: cargo build
-      - name: Install cargo-hack
-        uses: taiki-e/install-action@cargo-hack
-      - run: rustup target add thumbv7m-none-eabi
-      - run: cargo hack build --target thumbv7m-none-eabi --no-default-features --no-dev-deps
 
   clippy:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,3 +32,6 @@ fastrand = "1.3.3"
 [features]
 default = ["std"]
 std = []
+
+[build-dependencies]
+autocfg = "1.1.0"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,18 @@
+//! Build constants emitted by this script are *not* public API.
+
+fn main() {
+    let cfg = match autocfg::AutoCfg::new() {
+        Ok(cfg) => cfg,
+        Err(e) => {
+            println!(
+                "cargo:warning=concurrent-queue: failed to detect compiler features: {}",
+                e
+            );
+            return;
+        }
+    };
+
+    if !cfg.probe_rustc_version(1, 56) {
+        autocfg::emit("concurrent_queue_no_unwind_in_core");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@
 //! `concurrent-queue` used an `std` default feature. With this feature enabled, this crate will
 //! use [`std::thread::yield_now`] to avoid busy waiting in tight loops. However, with this
 //! feature disabled, [`core::hint::spin_loop`] will be used instead. Disabling `std` will allow
-//! this crate to be used on `no_std` platforms at the potential expense of more busy waiting. 
+//! this crate to be used on `no_std` platforms at the potential expense of more busy waiting.
 //! However, this feature has no effect on Rust versions prior to 1.56.
 //!
 //! [Bounded]: `ConcurrentQueue::bounded()`


### PR DESCRIPTION
#22 introduced a breaking change because, under `no-default-features`, `ConcurrentQueue<T>` no longer implemented `UnwindSafe` because it was exclusive to `libstd` prior to 1.56. This PR adds `autocfg` to detect whether or not we are running in Rust 1.56. If we are, it uses `UnwindSafe` from `libcore`. Otherwise, disabling the `std` feature has no effect.

My only concern is that this PR may introduce a footgun for users of old compilers.