### PR TITLE
v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Version 2.0.0
+
+- Add support for the `portable_atomic` and `loom` crates. (#27)
+- **Breaking:** Add an `std` feature that can be disabled to use this crate on `no_std` platforms. (#22)
+- Replace usage of `cache-padded` with `crossbeam-utils`. (#26)
+
 # Version 1.2.4
 
 - Fix fence on x86 and miri. (#18)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,8 +3,12 @@ name = "concurrent-queue"
 # When publishing a new version:
 # - Update CHANGELOG.md
 # - Create "v1.x.y" git tag
-version = "1.2.4"
-authors = ["Stjepan Glavina <stjepang@gmail.com>"]
+version = "2.0.0"
+authors = [
+    "Stjepan Glavina <stjepang@gmail.com>",
+    "Taiki Endo <te316e89@gmail.com>",
+    "John Nunley <jtnunley01@gmail.com>"
+]
 edition = "2018"
 rust-version = "1.38"
 description = "Concurrent multi-producer multi-consumer queue"


### PR DESCRIPTION
Changes:

- Add support for the the `portable_atomic` and `loom` crates. (#27)
- **Breaking:** Add an `std` feature that can be disabled to use this crate on `no_std` platforms. (#22)
- Replace usage of `cache-padded` with `crossbeam-utils`. (#26)