### PR TITLE
add get_head() and get_tail() methods

### DIFF
--- a/src/single.rs
+++ b/src/single.rs
@@ -4,7 +4,7 @@ use crate::sync::atomic::{AtomicUsize, Ordering};
 use crate::sync::cell::UnsafeCell;
 #[allow(unused_imports)]
 use crate::sync::prelude::*;
-use crate::{busy_wait, PopError, PushError};
+use crate::{busy_wait, GetError, PopError, PushError};
 
 const LOCKED: usize = 1 << 0;
 const PUSHED: usize = 1 << 1;
@@ -86,6 +86,14 @@ impl<T> Single<T> {
                 state = prev & !LOCKED;
             }
         }
+    }
+
+    pub fn head_mut(&mut self) -> Result<&mut T, GetError> {
+        todo!()
+    }
+
+    pub fn tail_mut(&mut self) -> Result<&mut T, GetError> {
+        todo!()
     }
 
     /// Returns the number of items in the queue.

--- a/src/unbounded.rs
+++ b/src/unbounded.rs
@@ -8,7 +8,7 @@ use crate::sync::atomic::{AtomicPtr, AtomicUsize, Ordering};
 use crate::sync::cell::UnsafeCell;
 #[allow(unused_imports)]
 use crate::sync::prelude::*;
-use crate::{busy_wait, PopError, PushError};
+use crate::{busy_wait, GetError, PopError, PushError};
 
 // Bits indicating the state of a slot:
 // * If a value has been written into the slot, `WRITE` is set.
@@ -334,6 +334,14 @@ impl<T> Unbounded<T> {
                 }
             }
         }
+    }
+
+    pub fn head_mut(&mut self) -> Result<&mut T, GetError> {
+        todo!()
+    }
+
+    pub fn tail_mut(&mut self) -> Result<&mut T, GetError> {
+        todo!()
     }
 
     /// Returns the number of items in the queue.


### PR DESCRIPTION
The discussion that led to this pr is #40. 

This pr adds a method `get_head()` and `get_tail()`, both methods returning the values stored in such positions. There's also a new error type introduced, `GetError`.