### PR TITLE
v2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Version 2.3.0
+
+- Implement `UnwindSafe` without libstd. (#49)
+- Bump `fastrand` to `v2.0.0`. (#43)
+- Use inline assembly in the `full_fence` funtion. (#47)
+
 # Version 2.2.0
 
 - Add the try_iter method. (#36)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,8 +2,8 @@
 name = "concurrent-queue"
 # When publishing a new version:
 # - Update CHANGELOG.md
-# - Create "v1.x.y" git tag
-version = "2.2.0"
+# - Create "v2.x.y" git tag
+version = "2.3.0"
 authors = [
     "Stjepan Glavina <stjepang@gmail.com>",
     "Taiki Endo <te316e89@gmail.com>",


### PR DESCRIPTION
- Implement `UnwindSafe` without libstd. (#49)
- Bump `fastrand` to `v2.0.0`. (#43)
- Use inline assembly in the `full_fence` funtion. (#47)