### PR TITLE
v2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 2.4.0
+
+- Remove unnecessary heap allocations from inside of the `ConcurrentQueue` type. (#53)
+
 # Version 2.3.0
 
 - Implement `UnwindSafe` without libstd. (#49)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "concurrent-queue"
 # When publishing a new version:
 # - Update CHANGELOG.md
 # - Create "v2.x.y" git tag
-version = "2.3.0"
+version = "2.4.0"
 authors = [
     "Stjepan Glavina <stjepang@gmail.com>",
     "Taiki Endo <te316e89@gmail.com>",


### PR DESCRIPTION
- Remove unnecessary heap allocations from inside of the `ConcurrentQueue` type. (#53)
