### PR TITLE
Relax MSRV to 1.60 and migrate to Rust 2021

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,21 +61,13 @@ jobs:
 
   msrv:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        # When updating this, the reminder to update the minimum supported
-        # Rust version in Cargo.toml.
-        rust: ['1.61']
     steps:
       - uses: actions/checkout@v4
-      - name: Install Rust
-        run: rustup update ${{ matrix.rust }} && rustup default ${{ matrix.rust }}
-      - run: cargo build
-      - run: cargo build --features portable-atomic
       - name: Install cargo-hack
         uses: taiki-e/install-action@cargo-hack
-      - run: rustup target add thumbv7m-none-eabi
-      - run: cargo hack build --target thumbv7m-none-eabi --no-default-features --no-dev-deps
+      - run: cargo hack build --rust-version
+      - run: cargo hack build --features portable-atomic --rust-version
+      - run: cargo hack build --target thumbv7m-none-eabi --no-default-features --no-dev-deps --rust-version
 
   clippy:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ authors = [
     "Taiki Endo <te316e89@gmail.com>",
     "John Nunley <dev@notgull.net>"
 ]
-edition = "2018"
+edition = "2021"
 rust-version = "1.60"
 description = "Concurrent multi-producer multi-consumer queue"
 license = "Apache-2.0 OR MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ authors = [
     "John Nunley <dev@notgull.net>"
 ]
 edition = "2018"
-rust-version = "1.61"
+rust-version = "1.60"
 description = "Concurrent multi-producer multi-consumer queue"
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/smol-rs/concurrent-queue"


### PR DESCRIPTION
- Relax MSRV to 1.60
  Refs: https://github.com/crossbeam-rs/crossbeam/pull/1056
- Migrate to Rust 2021
- Use cargo-hack's --rust-version flag for msrv check
  This respects rust-version field in Cargo.toml, so it removes the need to manage MSRV in both the CI file and Cargo.toml.
