### PR TITLE
Remove dead code

### DIFF
--- a/src/sync.rs
+++ b/src/sync.rs
@@ -62,10 +62,6 @@ pub(crate) mod prelude {
     pub(crate) trait UnsafeCellExt {
         type Value;
 
-        fn with<R, F>(&self, f: F) -> R
-        where
-            F: FnOnce(*const Self::Value) -> R;
-
         fn with_mut<R, F>(&self, f: F) -> R
         where
             F: FnOnce(*mut Self::Value) -> R;
@@ -73,13 +69,6 @@ pub(crate) mod prelude {
 
     impl<T> UnsafeCellExt for cell::UnsafeCell<T> {
         type Value = T;
-
-        fn with<R, F>(&self, f: F) -> R
-        where
-            F: FnOnce(*const Self::Value) -> R,
-        {
-            f(self.get())
-        }
 
         fn with_mut<R, F>(&self, f: F) -> R
         where


### PR DESCRIPTION
```
error: method `with` is never used
  --> src/sync.rs:65:12
   |
62 |     pub(crate) trait UnsafeCellExt {
   |                      ------------- method in this trait
...
65 |         fn with<R, F>(&self, f: F) -> R
   |            ^^^^
   |
   = note: `-D dead-code` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(dead_code)]`
```