### PR TITLE
Add loom test to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,18 @@ jobs:
           MIRIFLAGS: -Zmiri-strict-provenance -Zmiri-symbolic-alignment-check -Zmiri-disable-isolation
           RUSTFLAGS: ${{ env.RUSTFLAGS }} -Z randomize-layout
 
+  loom:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust
+        run: rustup update stable
+      - name: Loom tests
+        run: cargo test --release --test loom --features loom  
+        env:
+          RUSTFLAGS: "--cfg=loom"
+          LOOM_MAX_PREEMPTIONS: 4
+
   security_audit:
     permissions:
       checks: write


### PR DESCRIPTION
I'm unsure why this wasn't added to begin with. This adds Loom testing
to the CI with a low number of max pre-emptions, in order to avoid
making the test take forever.

cc https://github.com/smol-rs/event-listener/pull/126#issue-2214269916
