### PR TITLE
Test loom under no-default-features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,11 @@ jobs:
         env:
           RUSTFLAGS: "--cfg=loom"
           LOOM_MAX_PREEMPTIONS: 4
+      - name: Loom tests without default features
+        run: cargo test --release --test loom --features loom --no-default-features 
+        env:
+          RUSTFLAGS: "--cfg=loom"
+          LOOM_MAX_PREEMPTIONS: 4
 
   security_audit:
     permissions:

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -30,12 +30,13 @@ mod sync_impl {
 
 #[cfg(loom)]
 mod sync_impl {
-    pub(crate) use loom::cell;
+    pub(crate) use loom::{cell, hint::spin_loop};
 
     pub(crate) mod atomic {
         pub(crate) use loom::sync::atomic::*;
     }
 
+    #[cfg(not(feature = "std"))]
     pub(crate) use loom::thread::yield_now;
 }
 


### PR DESCRIPTION
This commit adds loom tests to CI with --no-default-features, then also fixes a compile error that was introduced in a new version of loom.

Closes #64
