### PR TITLE
v2.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Version 2.5.0
+
+- Add a `force_push` method that can be used to add an element to the queue by displacing another. (#58)
+- Make `ConcurrentQueue::unbounded()` into a `const` function. (#67)
+- Fix a compilation error in the Loom implementation. (#65)
+
 # Version 2.4.0
 
 - Remove unnecessary heap allocations from inside of the `ConcurrentQueue` type. (#53)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "concurrent-queue"
 # When publishing a new version:
 # - Update CHANGELOG.md
 # - Create "v2.x.y" git tag
-version = "2.4.0"
+version = "2.5.0"
 authors = [
     "Stjepan Glavina <stjepang@gmail.com>",
     "Taiki Endo <te316e89@gmail.com>",


### PR DESCRIPTION
- Add a `force_push` method that can be used to add an element to the queue by displacing another. (#58)
- Make `ConcurrentQueue::unbounded()` into a `const` function. (#67)
- Fix a compilation error in the Loom implementation. (#65)
