### PR TITLE
Make unbounded a const function

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,7 +140,7 @@ impl<T> ConcurrentQueue<T> {
     ///
     /// let q = ConcurrentQueue::<i32>::unbounded();
     /// ```
-    pub fn unbounded() -> ConcurrentQueue<T> {
+    pub const fn unbounded() -> ConcurrentQueue<T> {
         ConcurrentQueue(Inner::Unbounded(Unbounded::new()))
     }
 

--- a/src/unbounded.rs
+++ b/src/unbounded.rs
@@ -149,7 +149,7 @@ pub struct Unbounded<T> {
 
 impl<T> Unbounded<T> {
     /// Creates a new unbounded queue.
-    pub fn new() -> Unbounded<T> {
+    pub const fn new() -> Unbounded<T> {
         Unbounded {
             head: CachePadded::new(Position {
                 block: AtomicPtr::new(ptr::null_mut()),


### PR DESCRIPTION
This PR makes `ConcurrentQueue::unbounded` a const function. It'd be great if `bounded` could be `const` as well, but this would likely require static memory allocation support in const functions, which is currently not allowed by the compiler. This would enable https://github.com/smol-rs/async-executor/pull/112 to be directly constructable in a const context (i.e. static/thread_local variable initialization without OnceLock).