### PR TITLE
chore: fix spurious clippy warning

### DIFF
--- a/src/unbounded.rs
+++ b/src/unbounded.rs
@@ -41,6 +41,7 @@ struct Slot<T> {
 
 impl<T> Slot<T> {
     #[cfg(not(loom))]
+    #[allow(clippy::declare_interior_mutable_const)]
     const UNINIT: Slot<T> = Slot {
         value: UnsafeCell::new(MaybeUninit::uninit()),
         state: AtomicUsize::new(0),


### PR DESCRIPTION
```
warning: a `const` item should not be interior mutable
  --> src/unbounded.rs:44:5
   |
44 | /     const UNINIT: Slot<T> = Slot {
45 | |         value: UnsafeCell::new(MaybeUninit::uninit()),
46 | |         state: AtomicUsize::new(0),
47 | |     };
   | |______^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#declare_interior_mutable_const
   = note: `#[warn(clippy::declare_interior_mutable_const)]` on by default
```