### PR TITLE
ci: Use reusable workflows for fmt and security_audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,16 @@ defaults:
     shell: bash
 
 jobs:
+  fmt:
+    uses: smol-rs/.github/.github/workflows/fmt.yml@main
+  security_audit:
+    uses: smol-rs/.github/.github/workflows/security_audit.yml@main
+    permissions:
+      checks: write
+      contents: read
+      issues: write
+    secrets: inherit
+
   test:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -77,14 +87,6 @@ jobs:
         run: rustup update stable
       - run: cargo clippy --all-features --all-targets
 
-  fmt:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install Rust
-        run: rustup update stable
-      - run: cargo fmt --all --check
-
   miri:
     runs-on: ubuntu-latest
     steps:
@@ -103,28 +105,12 @@ jobs:
       - name: Install Rust
         run: rustup update stable
       - name: Loom tests
-        run: cargo test --release --test loom --features loom  
+        run: cargo test --release --test loom --features loom
         env:
           RUSTFLAGS: "--cfg=loom"
           LOOM_MAX_PREEMPTIONS: 4
       - name: Loom tests without default features
-        run: cargo test --release --test loom --features loom --no-default-features 
+        run: cargo test --release --test loom --features loom --no-default-features
         env:
           RUSTFLAGS: "--cfg=loom"
           LOOM_MAX_PREEMPTIONS: 4
-
-  security_audit:
-    permissions:
-      checks: write
-      contents: read
-      issues: write
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      # rustsec/audit-check used to do this automatically
-      - name: Generate Cargo.lock
-        run: cargo generate-lockfile
-      # https://github.com/rustsec/audit-check/issues/2
-      - uses: rustsec/audit-check@v2.0.0
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}

--- a/src/bounded.rs
+++ b/src/bounded.rs
@@ -231,7 +231,7 @@ impl<T> Bounded<T> {
             let slot = &self.buffer[index];
             let stamp = slot.stamp.load(Ordering::Acquire);
 
-            // If the the stamp is ahead of the head by 1, we may attempt to pop.
+            // If the stamp is ahead of the head by 1, we may attempt to pop.
             if head + 1 == stamp {
                 let new = if index + 1 < self.buffer.len() {
                     // Same lap, incremented index.


### PR DESCRIPTION
See https://github.com/smol-rs/.github/pull/1 for details about reusable workflows.
